### PR TITLE
virion.md: fix erroneous package and scheme.

### DIFF
--- a/virion.md
+++ b/virion.md
@@ -149,13 +149,11 @@ To develop a virion, create a composer library by creating the composer.json:
 {
   "name": "sof3/await-generator",
   "require": {
-    "pmmp/pocketmine-mp": "^4.13.0", # RECOMMENDED unless virion does not use PM API
+    "pocketmine/pocketmine-mp": "^5.0.0", # RECOMMENDED unless virion does not use PM API
     "php": "^8.1" # OPTIONAL but RECOMMENDED if pmmp/pocketmine-mp is omitted
   },
   "autoload": {
-    "psr-4": {
-      "SOFe\\AwaitGenerator\\": "src"
-    }
+    "classmap": ["FolderContainingPluginYml/src"]
   },
   "extra": {
     "virion": {
@@ -185,12 +183,10 @@ To use a virion, first create a composer.json for your project:
 {
   "name": "author/project",
   "require": {
-    "pmmp/pocketmine-mp": "^4.13.0"
+    "pocketmine/pocketmine-mp": "^5.0.0"
   },
   "autoload": {
-    "psr-4": {
-      "Author\\Plugin": "src"
-    }
+    "classmap": ["FolderContainingPluginYml/src"]
   }
 }
 ```
@@ -203,12 +199,10 @@ just like normal composer libraries:
     "name": "author/project",
     "require": {
 +     "sof3/await-generator": "^3.0.0",
-      "pmmp/pocketmine-mp": "^4.13.0"
+      "pocketmine/pocketmine-mp": "^5.0.0"
     },
     "autoload": {
-      "psr-4": {
-        "Author\\Plugin": "src"
-      }
+      "classmap": ["FolderContainingPluginYml/src"]
     }
   }
 ```

--- a/virion.md
+++ b/virion.md
@@ -153,7 +153,9 @@ To develop a virion, create a composer library by creating the composer.json:
     "php": "^8.1" # OPTIONAL but RECOMMENDED if pmmp/pocketmine-mp is omitted
   },
   "autoload": {
-    "SOFe\\AwaitGenerator\\": "src"
+    "psr-4": {
+      "SOFe\\AwaitGenerator\\": "src"
+    }
   },
   "extra": {
     "virion": {
@@ -186,7 +188,9 @@ To use a virion, first create a composer.json for your project:
     "pmmp/pocketmine-mp": "^4.13.0"
   },
   "autoload": {
-    "Author\\Plugin": "src"
+    "psr-4": {
+      "Author\\Plugin": "src"
+    }
   }
 }
 ```
@@ -202,7 +206,9 @@ just like normal composer libraries:
       "pmmp/pocketmine-mp": "^4.13.0"
     },
     "autoload": {
-      "Author\\Plugin": "src"
+      "psr-4": {
+        "Author\\Plugin": "src"
+      }
     }
   }
 ```


### PR DESCRIPTION
- “autoload” mismatching the composer.json scheme.
  - (advocate classmap instead of PSR-4.)
- Incorrect vendor of pocketmine-mp package.
  - (bumped version to ^5.0.0 as well)